### PR TITLE
Remove Tesseract OSD module dependency check.

### DIFF
--- a/lib/docsplit.rb
+++ b/lib/docsplit.rb
@@ -16,7 +16,7 @@ module Docsplit
   
   GM_FORMATS    = ["image/gif", "image/jpeg", "image/png", "image/x-ms-bmp", "image/svg+xml", "image/tiff", "image/x-portable-bitmap", "application/postscript", "image/x-portable-pixmap"]
 
-  DEPENDENCIES  = {:java => false, :gm => false, :pdftotext => false, :pdftk => false, :pdftailor => false, :tesseract => false, :osd => false}
+  DEPENDENCIES  = {:java => false, :gm => false, :pdftotext => false, :pdftk => false, :pdftailor => false, :tesseract => false}
 
   # Check for all dependencies, and note their absence.
   dirs = ENV['PATH'].split(File::PATH_SEPARATOR)
@@ -29,14 +29,7 @@ module Docsplit
     end
   end
 
-  # if tesseract is found check for the osd plugin so that we can do orientation independent OCR.
-  if DEPENDENCIES[:tesseract]
-    # osd will be listed in tesseract --listlangs
-    val = %x[ #{'tesseract --list-langs'} 2>&1 >/dev/null ]
-    DEPENDENCIES[:osd] = true if val =~ /\bosd\b/
-  end
-
-    # Raise an ExtractionFailed exception when the PDF is encrypted, or otherwise
+  # Raise an ExtractionFailed exception when the PDF is encrypted, or otherwise
   # broke.
   class ExtractionFailed < StandardError; end
 

--- a/lib/docsplit/text_extractor.rb
+++ b/lib/docsplit/text_extractor.rb
@@ -134,7 +134,7 @@ module Docsplit
       @forbid_ocr         = options[:ocr] == false
       @language           = options[:language] || 'eng'
       @clean_ocr          = (!(options[:clean] == false) and @language == 'eng')
-      @detect_orientation = ((options[:detect_orientation] != false) and DEPENDENCIES[:osd])
+      @detect_orientation = options[:detect_orientation] != false
       @keep_layout        = options.fetch(:layout, false)
     end
 

--- a/test/unit/test_extract_text.rb
+++ b/test/unit/test_extract_text.rb
@@ -53,32 +53,28 @@ class ExtractTextTest < Minitest::Test
     Docsplit.extract_text('test/fixtures/PDF file with spaces \'single\' and "double quotes".pdf', :pages => 'all', :output => OUTPUT)
     assert Dir["#{OUTPUT}/*.txt"].length == 2
   end
-  
+
   def test_orientation_detected_ocr_extraction
-    if Docsplit::DEPENDENCIES[:osd]
-      pages = 1..4
-      Docsplit.extract_text('test/fixtures/corrosion.reoriented.pdf', :output => OUTPUT, :pages=>pages, :force_ocr => true)
-      letters = Hash.new(0)
-      nonletters = Hash.new(0)
-      
-      pages.each do |number|
-        File.open(File.join(OUTPUT,"corrosion.reoriented_#{number}.txt")).each_char do |c| 
-          case c
-          when /[A-Za-z]/
-            letters[c] += 1
-          when /\s/
-          else
-            nonletters[c] += 1
-          end
+    pages = 1..4
+    Docsplit.extract_text('test/fixtures/corrosion.reoriented.pdf', :output => OUTPUT, :pages=>pages, :ocr => true)
+    letters = Hash.new(0)
+    nonletters = Hash.new(0)
+
+    pages.each do |number|
+      File.open(File.join(OUTPUT,"corrosion.reoriented_#{number}.txt")).each_char do |c|
+        case c
+        when /[A-Za-z]/
+          letters[c] += 1
+        when /\s/
+        else
+          nonletters[c] += 1
         end
       end
-      
-      # the corrosion.pdf has 6160 letters & 362 nonletters, or ~17:1
-      # so lets give a fudge factor of ~half of that or 8:1
-      assert letters.values.reduce(0,:+)/8 > nonletters.values.reduce(0,:+), "Expected that text extracted with orientation detection would have more letters."
-    else
-      skip "Orientation detection module (osd) for Tesseract isn't installed"
     end
+
+    # the corrosion.pdf has 6160 letters & 362 nonletters, or ~17:1
+    # so lets give a fudge factor of ~half of that or 8:1
+    assert letters.values.reduce(0,:+)/8 > nonletters.values.reduce(0,:+), "Expected that text extracted with orientation detection would have more letters."
   end
 
 end


### PR DESCRIPTION
Package tesseract-ocr-osd is a dependency of tesseract-ocr. See https://packages.debian.org/stretch/tesseract-ocr