### PR TITLE
PDF OCR: New --psm option

### DIFF
--- a/lib/docsplit/command_line.rb
+++ b/lib/docsplit/command_line.rb
@@ -100,6 +100,9 @@ Options:
         opts.on('--no-orientation-detection', 'turn off automatic orientation detection in tesseract') do |n|
           @options[:detect_orientation] = false
         end
+        opts.on('--psm', 'set page segmentation mode for tesseract OCR') do |n|
+          @options[:psm] = n
+        end
         opts.on('-r', '--rolling', 'generate images from each previous image') do |r|
           @options[:rolling] = true
         end

--- a/lib/docsplit/text_extractor.rb
+++ b/lib/docsplit/text_extractor.rb
@@ -60,7 +60,13 @@ module Docsplit
       tempdir = Dir.mktmpdir
       base_path = File.join(@output, @pdf_name)
       escaped_pdf = ESCAPE[pdf]
-      psm = @detect_orientation ? "-psm 1" : ""
+      psm = if @psm
+              "--psm #{@psm}"
+            elsif @detect_orientation
+              '--psm 1'
+            else
+              ''
+            end
       if pages
         pages.each do |page|
           tiff = "#{tempdir}/#{@pdf_name}_#{page}.tif"
@@ -135,6 +141,7 @@ module Docsplit
       @language           = options[:language] || 'eng'
       @clean_ocr          = (!(options[:clean] == false) and @language == 'eng')
       @detect_orientation = options[:detect_orientation] != false
+      @psm                = options[:psm]
       @keep_layout        = options.fetch(:layout, false)
     end
 


### PR DESCRIPTION
Allow users to pick the most effective page segmentation mode to process their PDF documents if the default does not produce desired results.

See https://github.com/tesseract-ocr/tesseract/wiki/Command-Line-Usage#using-different-page-segmentation-modes for an example.